### PR TITLE
Benchmarks for licu and iminuit samplers

### DIFF
--- a/benchmarks/asv/sampling_suite.py
+++ b/benchmarks/asv/sampling_suite.py
@@ -4,6 +4,8 @@ import numpy as np
 
 from superphot_plus.lightcurve import Lightcurve
 from superphot_plus.samplers.dynesty_sampler import DynestySampler
+from superphot_plus.samplers.iminuit_sampler import IminuitSampler
+from superphot_plus.samplers.licu_sampler import LiCuSampler
 from superphot_plus.samplers.numpyro_sampler import NumpyroSampler
 from superphot_plus.surveys.surveys import Survey
 
@@ -19,6 +21,36 @@ class SamplingSuite:
         lightcurve = Lightcurve.from_file(SINGLE_ZTF_LIGHTCURVE_COMPRESSED)
         posteriors = sampler.run_single_curve(
             lightcurve, priors=Survey.ZTF().priors, rstate=np.random.default_rng(9876)
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            posteriors.save_to_file(tmp_dir)
+
+    def time_iminuit_single_file(self):
+        """Benchmarks the iminuit optimizer"""
+        sampler = IminuitSampler()
+        lightcurve = Lightcurve.from_file(SINGLE_ZTF_LIGHTCURVE_COMPRESSED)
+        posteriors = sampler.run_single_curve(
+            lightcurve, priors=Survey.ZTF().priors, rstate=np.random.default_rng(9876)
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            posteriors.save_to_file(tmp_dir)
+
+    def time_licu_ceres_single_file(self):
+        """Benchmarks the iminuit optimizer"""
+        sampler = LiCuSampler(algorithm="ceres")
+        lightcurve = Lightcurve.from_file(SINGLE_ZTF_LIGHTCURVE_COMPRESSED)
+        posteriors = sampler.run_single_curve(
+            lightcurve, priors=Survey.ZTF().priors
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            posteriors.save_to_file(tmp_dir)
+
+    def time_licu_mcmc_ceres_single_file(self):
+        """Benchmarks the iminuit optimizer"""
+        sampler = LiCuSampler(algorithm="mcmc-ceres", mcmc_niter=10_000)
+        lightcurve = Lightcurve.from_file(SINGLE_ZTF_LIGHTCURVE_COMPRESSED)
+        posteriors = sampler.run_single_curve(
+            lightcurve, priors=Survey.ZTF().priors
         )
         with tempfile.TemporaryDirectory() as tmp_dir:
             posteriors.save_to_file(tmp_dir)

--- a/benchmarks/benchmark_samplers.py
+++ b/benchmarks/benchmark_samplers.py
@@ -13,6 +13,8 @@ from memory_profiler import memory_usage
 from superphot_plus.data_generation.make_fake_spp_data import create_clean_models, create_ztf_model
 from superphot_plus.lightcurve import Lightcurve
 from superphot_plus.samplers.dynesty_sampler import DynestySampler
+from superphot_plus.samplers.iminuit_sampler import IminuitSampler
+from superphot_plus.samplers.licu_sampler import LiCuSampler
 from superphot_plus.samplers.numpyro_sampler import NumpyroSampler
 from superphot_plus.surveys.surveys import Survey
 from superphot_plus.utils import calculate_log_likelihood, calculate_mse
@@ -85,6 +87,12 @@ def setup_sampler(sampler_name, seed, **kwargs):
     elif sampler_name == "NUTS":
         sampler_obj = DynestySampler()
         kwargs2["sampler"] = "NUTS"
+    elif sampler_name == "iminuit":
+        sampler_obj = IminuitSampler()
+    elif sampler_name == "licu-ceres":
+        sampler_obj = LiCuSampler(algorithm="ceres")
+    elif sampler_name == "licu-mcmc-ceres":
+        sampler_obj = LiCuSampler(algorithm="mcmc-ceres", mcmc_niter=10_000)
     else:
         raise ValueError(f"Unknown sampler {sampler_name}")
 
@@ -140,7 +148,7 @@ def run_all_benchmarks(num_samples):
     _, lightcurves = create_data(num_samples, True)
 
     seed = int.from_bytes(urandom(4), "big")
-    samplers = ["dynesty", "svi", "NUTS"]
+    samplers = ["dynesty", "svi", "NUTS", "iminuit", "licu-ceres", "licu-mcmc-ceres"]
 
     results = {}
     for sampler in samplers:


### PR DESCRIPTION
Adds benchmarks for `LiCuSampler` and `IminuitSampler` to both ASV and `benchmark_samplers.py`

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

Output from `benchmark_samplers.py`:

```
Final results for dynesty sampler:
  Ave Running Time: 30.65139977920335
  Ave Memory Usage: 3282.4890625
  Ave LL: 627.9808370972921
  Ave MSE: 9.70243104454952e-07

Final results for svi sampler:
  Ave Running Time: 9.208758364502865
  Ave Memory Usage: 3638.16796875
  Ave LL: -7855.026511614686
  Ave MSE: 0.1956701679840977

Final results for NUTS sampler:
  Ave Running Time: 23.37863515815552
  Ave Memory Usage: 3521.0328125
  Ave LL: 488.607271295606
  Ave MSE: 1.1424518433835922e-06

Final results for iminuit sampler:
  Ave Running Time: 0.5169179165997775
  Ave Memory Usage: 3464.78359375
  Ave LL: -2512.3828778719976
  Ave MSE: 2.3160990250962583

Final results for licu-ceres sampler:
  Ave Running Time: 0.0017882771498989314
  Ave Memory Usage: 3460.7515625
  Ave LL: -599323.4503857349
  Ave MSE: 5.981564372305995

Final results for licu-mcmc-ceres sampler:
  Ave Running Time: 0.4130233978488832
  Ave Memory Usage: 3470.759375
  Ave LL: -596726.0845997606
  Ave MSE: 0.13737526053174695
```